### PR TITLE
Add functionality for Spoolman URL barcodes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ spool IDs in AFC.
 
 Once the service is running, the utility will listen for events from the connected USB 
 2D barcode scanner. If a scanned code begins with the magic spoolman prefix `web+spoolman:s-`,
-it will send a `SET_NEXT_SPOOL_ID SPOOL_ID=#` command to AFC for the next spool to be loaded.
+or the scanned code is a URL `Base URL\spool\show\`, it will send a `SET_NEXT_SPOOL_ID SPOOL_ID=#` 
+command to AFC for the next spool to be loaded.
 
 Here's the scanner that I'm using, but it's expected that most of the 2D barcode scanners
 will work with this method: https://www.amazon.com/dp/B0DYY7GLSL

--- a/usb-qr-scanner-read.sh
+++ b/usb-qr-scanner-read.sh
@@ -28,7 +28,12 @@ post_next_spool_id() {
 process_line() {
     local line="$1"
     if [[ "$line" == "$SPOOLMAN_PREFIX"* ]]; then
+        echo "Magic code Scanned"
         SPOOL_ID="${line#$SPOOLMAN_PREFIX}"
+        post_next_spool_id "${SPOOL_ID}"
+    elif [[ "$line" == "http"* ]]; then
+        echo "URL Scanned"
+        SPOOL_ID=`echo $line | cut -d'/' -f6`
         post_next_spool_id "${SPOOL_ID}"
     fi
 }


### PR DESCRIPTION
Added functionality to read URL barcodes `BaseURLi/spool/show/{id}` in addition to the default `web+spoolman:s-{id}` barcodes.